### PR TITLE
Run as non-root and set security context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/docs
+/build

--- a/build/container/Dockerfile
+++ b/build/container/Dockerfile
@@ -22,4 +22,13 @@ LABEL org.opencontainers.image.description="Lightweight, elastic, kubernetes-nat
 
 WORKDIR /work/
 COPY --from=builder /build/barco .
+
+RUN mkdir /var/lib/barco
+
+RUN chgrp -R 0 /var/lib/barco && \
+    chmod -R g=u /var/lib/barco && \
+    chown -R 1001:0 /var/lib/barco
+
+USER 1001
+
 CMD ["/work/barco"]

--- a/deploy/kubernetes/barco.yaml
+++ b/deploy/kubernetes/barco.yaml
@@ -101,6 +101,14 @@ spec:
       - name: barco
         image: barcostreams/barco:dev1
         imagePullPolicy: Always
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
         ports:
         - containerPort: 9250
           name: discovery


### PR DESCRIPTION
Fixes #17 and #18.

It adds `seccompProfile`, `runAsNonRoot`, `allowPrivilegeEscalation: false` and drops all `capabilities` from the container.

Additionally, it sets a non-root user in the `Dockerfile` to work with both OpenShift & Kubernetes as non-root, unpriviledged.