### PR TITLE
Drop support for HTTP/2 on the producer server

### DIFF
--- a/internal/test/integration/roundtrip_test.go
+++ b/internal/test/integration/roundtrip_test.go
@@ -113,9 +113,6 @@ var _ = Describe("A 3 node cluster", func() {
 			Expect(item.records[0].timestamp.UnixMilli()).To(BeNumerically("<=", time.Now().UnixMilli()))
 			Expect(item.records[0].body).To(Equal(message))
 
-			// Test with HTTP/1
-			expectOk(NewTestClient(&TestClientOptions{HttpVersion: 1}).ProduceJson(0, "abc", message, ""))
-
 			client.Close()
 		})
 


### PR DESCRIPTION
HTTP/2 can break request and responses into multiple streamids each, interleaving _partial_ request bodies.
If we don't allocate memory to read in parrallel, we can't independently move forward a request body without moving the whole stream forward. The resolution is to remove HTTP/2 support.

Fixes #56.