### PR TITLE
fix: Segment file mismatch on replicas

### DIFF
--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -1,4 +1,4 @@
-### Installing Barco Streams on Kubernetes
+# Installing Barco Streams on Kubernetes
 
 You can use `kubectl` to install Barco on Kubernetes.
 

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -87,3 +87,10 @@ func (s *ReadSegmentChunk) StartOffset() int64 {
 func (s *ReadSegmentChunk) RecordLength() uint32 {
 	return s.Length
 }
+
+type writerType string
+
+const (
+	replicaWriter writerType = "replica"
+	leaderWriter  writerType = "leader"
+)

--- a/internal/test/integration/test_cluster.go
+++ b/internal/test/integration/test_cluster.go
@@ -64,9 +64,15 @@ func NewTestBroker(ordinal int, options ...*TestBrokerOptions) *TestBroker {
 
 func (b *TestBroker) Start() {
 	buildOutput, err := exec.Command("go", "build", "-o", "barco.exe", "../../../.").CombinedOutput()
-	// buildOutput, err := exec.Command("go", "build", "-tags=profiling", "-o", "barco.exe", "../../../.").CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), "Build failed: %s", string(buildOutput))
-	cmd := exec.Command("./barco.exe", "-debug")
+
+	logPretty := ""
+
+	if os.Getenv("BARCO_TEST_LOG_PRETTY") == "true" {
+		logPretty = "-pretty"
+	}
+
+	cmd := exec.Command("./barco.exe", "-debug", logPretty)
 	os.RemoveAll(fmt.Sprintf("./home%d", b.ordinal))
 
 	names := make([]string, 0)


### PR DESCRIPTION
When writing at high throughput rates it was possible that replicas used the buffered offset instead of the original file name.

Fixes #76.