### PR TITLE
Fix get readers for generations that previously scaled down

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,4 +48,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          args: -D gosimple -D errcheck --tests=false --timeout=3m
+          args: -D errcheck --tests=false --timeout=3m

--- a/docs/getting_started/on_docker/README.md
+++ b/docs/getting_started/on_docker/README.md
@@ -3,7 +3,7 @@
 <!-- Start Intro -->
 
 Barco Streams is distributed by default with a minimal size of 3 brokers for production use. You can run a
-single-broker using Docker/Podman with developer mode enabled to get started quickly.
+single-broker using Docker / Podman with developer mode enabled to get started quickly.
 
 ```shell
 docker run --rm --env BARCO_DEV_MODE=true -p 9250-9252:9250-9252 barcostreams/barco:latest
@@ -68,3 +68,4 @@ instance as inactive and it will not be included in the data assignment.
 Read more about the API flow and guarantees on the [REST API Documentation][rest-api].
 
 [rest-api]: ../../rest_api/
+[go-client]: https://github.com/barcostreams/go-client

--- a/internal/consuming/group_read_queue_test.go
+++ b/internal/consuming/group_read_queue_test.go
@@ -369,4 +369,53 @@ var _ = Describe("groupReadQueue()", func() {
 
 		})
 	})
+
+	Describe("tokenRangesWithParents()", func() {
+		config := new(cMocks.Config)
+		config.On("ConsumerRanges").Return(4)
+		q := &groupReadQueue{config: config}
+		t3 := Token(-6148914691236517888)
+
+		It("should return the same range when single parent", func ()  {
+			gen := &Generation{
+				Start:   StartToken,
+				Version: 2,
+				Parents: []GenId{{
+					Start:   StartToken,
+					Version: 1,
+				}},
+			}
+
+			Expect(q.tokenRangesWithParents(gen, []RangeIndex{1})).
+				To(Equal([]TokenRanges{{Token: StartToken, Indices: []RangeIndex{1}}}))
+			Expect(q.tokenRangesWithParents(gen, []RangeIndex{3})).
+				To(Equal([]TokenRanges{{Token: StartToken, Indices: []RangeIndex{3}}}))
+		})
+
+		It("should project range when multiple parents when using 4 ranges", func() {
+			gen := &Generation{
+				Start:   StartToken,
+				Version: 2,
+				Parents: []GenId{{
+					Start:   StartToken,
+					Version: 1,
+				}, {
+					Start:   t3,
+					Version: 1,
+				}},
+			}
+
+			Expect(q.tokenRangesWithParents(gen, []RangeIndex{0})).
+				To(Equal([]TokenRanges{{Token: StartToken, Indices: []RangeIndex{0, 1}}}))
+
+			Expect(q.tokenRangesWithParents(gen, []RangeIndex{1})).
+				To(Equal([]TokenRanges{{Token: StartToken, Indices: []RangeIndex{2, 3}}}))
+
+			Expect(q.tokenRangesWithParents(gen, []RangeIndex{2})).
+				To(Equal([]TokenRanges{{Token: t3, Indices: []RangeIndex{0, 1}}}))
+
+			Expect(q.tokenRangesWithParents(gen, []RangeIndex{3})).
+				To(Equal([]TokenRanges{{Token: t3, Indices: []RangeIndex{2, 3}}}))
+		})
+	})
 })

--- a/internal/data/segment_writer.go
+++ b/internal/data/segment_writer.go
@@ -56,7 +56,7 @@ func NewSegmentWriter(
 	s := &SegmentWriter{
 		// Limit's to 1 outstanding write (the current one)
 		// The next group can be generated while the previous is being flushed and sent
-		Items:       make(chan SegmentChunk, 0),
+		Items:       make(chan SegmentChunk),
 		Topic:       topic,
 		buffer:      createAlignedByteBuffer(config.SegmentBufferSize()), // Use an aligned buffer for writing
 		config:      config,
@@ -175,7 +175,7 @@ func (s *SegmentWriter) maybeFlush() bool {
 	}
 
 	canBufferNextGroup := s.buffer.Len()+s.config.MaxGroupSize() < s.config.SegmentBufferSize()
-	if canBufferNextGroup && time.Now().Sub(s.lastFlush) < s.config.SegmentFlushInterval() {
+	if canBufferNextGroup && time.Since(s.lastFlush) < s.config.SegmentFlushInterval() {
 		// Time has not passed and there's enough capacity
 		// in the buffer for the next group
 		return false

--- a/internal/producing/coalescer.go
+++ b/internal/producing/coalescer.go
@@ -64,7 +64,7 @@ func newCoalescer(
 	config conf.ProducerConfig,
 ) *coalescer {
 	c := &coalescer{
-		items:           make(chan *recordItem, 0),
+		items:           make(chan *recordItem),
 		topicName:       topicName,
 		token:           token,
 		rangeIndex:      rangeIndex,

--- a/internal/types/models.go
+++ b/internal/types/models.go
@@ -163,7 +163,7 @@ func (t *TopologyInfo) BrokerByOrdinal(ordinal int) *BrokerInfo {
 
 // BrokerByOrdinal gets the broker by a given ordinal.
 func (t *TopologyInfo) BrokerByOrdinalList(ordinals []int) []BrokerInfo {
-	result := make([]BrokerInfo, len(ordinals), len(ordinals))
+	result := make([]BrokerInfo, len(ordinals))
 	for i, v := range ordinals {
 		result[i] = t.Brokers[int(t.GetIndex(v))]
 	}
@@ -200,7 +200,7 @@ func (t *TopologyInfo) NextIndex() BrokerIndex {
 // NextBrokers returns the broker in the position n+1, n+2, n...
 func (t *TopologyInfo) NextBrokers(index BrokerIndex, length int) []BrokerInfo {
 	totalBrokers := len(t.Brokers)
-	result := make([]BrokerInfo, length, length)
+	result := make([]BrokerInfo, length)
 	for i := 0; i < length; i++ {
 		result[i] = t.Brokers[(int(index)+1+i)%totalBrokers]
 	}


### PR DESCRIPTION
Fix getting the token ranges with parent generations and test it.