### PR TITLE
fix: Wait for replication write on all replicas

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
         go-version: 1.19
 
     - name: Build
-      run: go build -v ./...
+      run: go build ./...
 
     - name: Unit tests
       run: go test -v ./...
@@ -48,4 +48,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          args: -D errcheck --tests=false --timeout=3m
+          args: --tests=false --timeout=3m

--- a/internal/conf/config_linux.go
+++ b/internal/conf/config_linux.go
@@ -15,6 +15,7 @@ const SegmentFileReadFlags = readFileDirectFlags
 // Use page cache for index file as it's not critical and it won't abuse the cache space
 const IndexFileWriteFlags = os.O_APPEND | os.O_CREATE | os.O_WRONLY
 
-const ProducerOffsetFileWriteFlags = os.O_CREATE | os.O_WRONLY | syscall.O_DIRECT | syscall.O_DSYNC
+// Use page cache for max offset producer file as it won't abuse the cache space
+const ProducerOffsetFileWriteFlags = os.O_CREATE | os.O_WRONLY
 
-const ProducerOffsetFileReadFlags = readFileDirectFlags
+const ProducerOffsetFileReadFlags = os.O_RDONLY

--- a/internal/conf/config_os_default.go
+++ b/internal/conf/config_os_default.go
@@ -16,6 +16,6 @@ const SegmentFileReadFlags = readFileFlags
 
 const IndexFileWriteFlags = SegmentFileWriteFlags
 
-const ProducerOffsetFileWriteFlags = os.O_CREATE | os.O_WRONLY | os.O_SYNC
+const ProducerOffsetFileWriteFlags = os.O_CREATE | os.O_WRONLY
 
 const ProducerOffsetFileReadFlags = readFileFlags

--- a/internal/consuming/models.go
+++ b/internal/consuming/models.go
@@ -131,7 +131,7 @@ func (i *consumerResponseItem) MarshalJson(
 		// Use strings for int64 values
 		writer.KeyString("startOffset", strconv.FormatInt(i.chunk.StartOffset(), 10))
 		writer.Array("values", func() {
-			writeJsonRecords(writer, decoder, decoderBuffer)
+			_ = writeJsonRecords(writer, decoder, decoderBuffer)
 		})
 	})
 
@@ -153,7 +153,9 @@ func writeJsonRecords(
 			return err
 		}
 		writer.Separator()
-		writeRecordBody(int(header.Length), writer, reader, readBuffer)
+
+		// TODO: Handle error
+		_ = writeRecordBody(int(header.Length), writer, reader, readBuffer)
 	}
 }
 

--- a/internal/data/index_file_reader.go
+++ b/internal/data/index_file_reader.go
@@ -25,7 +25,7 @@ var indexItemSize = utils.BinarySize(indexOffset{})
 // Gets the known highest file offset from the index file that contains message offset
 func tryReadIndexFile(basePath string, filePrefix string, messageOffset int64) int64 {
 	// Use the OS page cache for reading index file
-	// as it will simplify the logic needed. The page cache usage should be neglegible for this
+	// as it will simplify the logic needed. The page cache usage should be negligible for this
 	// sporadic small files
 	indexFileName := filepath.Join(basePath, fmt.Sprintf("%s.%s", filePrefix, conf.IndexFileExtension))
 	file, err := os.Open(indexFileName)

--- a/internal/data/index_file_writer.go
+++ b/internal/data/index_file_writer.go
@@ -76,9 +76,11 @@ func (w *indexFileWriter) writeLoop() {
 
 		if item.fileOffset-lastStoredFileOffset >= writeThreshold {
 			buffer.Reset()
-			binary.Write(buffer, conf.Endianness, item.offset)
-			binary.Write(buffer, conf.Endianness, item.fileOffset)
-			binary.Write(buffer, conf.Endianness, crc32.ChecksumIEEE(buffer.Bytes()))
+			utils.PanicIfErr(binary.Write(buffer, conf.Endianness, item.offset), "Error writing item.offset")
+			utils.PanicIfErr(binary.Write(buffer, conf.Endianness, item.fileOffset), "Error writing item.fileOffset")
+			utils.PanicIfErr(binary.Write(buffer, conf.Endianness, crc32.ChecksumIEEE(buffer.Bytes())),
+				"Error writing item.checksum")
+
 			if _, err := file.Write(buffer.Bytes()); err != nil {
 				log.Err(err).Msgf("There was an error writing to the index file on path %s", w.basePath)
 			} else {

--- a/internal/data/index_file_writer_test.go
+++ b/internal/data/index_file_writer_test.go
@@ -124,7 +124,7 @@ func assertStored(basePath string, segmentId int64, values []indexOffset) {
 	}
 	// Wait for the data to be stored in the file
 	for i := 0; i < maxWaits; i++ {
-		time.Sleep(20)
+		time.Sleep(20 * time.Millisecond)
 		name := fmt.Sprintf("%020d.index", segmentId)
 		b, err := os.ReadFile(filepath.Join(basePath, name))
 		if err == nil && len(b) == expectedFileLength {
@@ -158,9 +158,9 @@ func assertProducerOffsetStored(basePath string, expected uint64) {
 
 	// Wait for the data to be stored in the file
 	for i := 0; i < maxWaits; i++ {
-		time.Sleep(20)
+		time.Sleep(20 * time.Millisecond)
 		b, err := os.ReadFile(filepath.Join(basePath, conf.ProducerOffsetFileName))
-		if err == nil && len(b) == alignmentSize {
+		if err == nil && len(b) == offsetFileSize {
 			buffer := bytes.NewBuffer(b)
 			binary.Read(buffer, conf.Endianness, &storedOffset)
 			if storedOffset == expected {
@@ -170,7 +170,7 @@ func assertProducerOffsetStored(basePath string, expected uint64) {
 		}
 	}
 
-	Expect(blob).To(HaveLen(alignmentSize))
+	Expect(blob).To(HaveLen(offsetFileSize))
 	buffer := bytes.NewBuffer(blob)
 
 	var storedChecksum uint32

--- a/internal/data/segment_reader.go
+++ b/internal/data/segment_reader.go
@@ -95,7 +95,7 @@ func (s *SegmentReader) startReading() {
 
 	if !s.isLeader {
 		// Start early to initialize in the background
-		s.initRead(false)
+		_ = s.initRead(false)
 	}
 
 	s.read()
@@ -160,7 +160,7 @@ func (s *SegmentReader) read() {
 
 		if s.segmentFile == nil {
 			// Segment file might be nil when there was no data initially
-			s.initRead(false)
+			_ = s.initRead(false)
 			if s.segmentFile == nil {
 				continue
 			}
@@ -200,7 +200,8 @@ func (s *SegmentReader) consumeReadAhead(reader *bytes.Reader, buf []byte, remai
 		// There isn't enough data remaining for a chunk.
 		*remainderIndex = reader.Len()
 		// Drain the remaining reader and copy the bytes to the beginning of the buffer
-		reader.Read(buf)
+		_, err := reader.Read(buf)
+		utils.PanicIfErr(err, "Error reading from buffer")
 	}
 
 	return chunk, offsetGap
@@ -615,7 +616,8 @@ func (s *SegmentReader) readSingleChunk(reader *bytes.Reader) (int, SegmentChunk
 
 	if reader.Len() < int(header.BodyLength) {
 		// Rewind to the header position
-		reader.Seek(-int64(chunkHeaderSize), io.SeekCurrent)
+		_, err := reader.Seek(-int64(chunkHeaderSize), io.SeekCurrent)
+		utils.PanicIfErr(err, "Reader seek resulted in error")
 		return n, nil
 	}
 

--- a/internal/interbroker/data_messages_test.go
+++ b/internal/interbroker/data_messages_test.go
@@ -28,7 +28,8 @@ var _ = Describe("fileStreamRequest", func() {
 			buf := new(bytes.Buffer)
 			header := header{Version: 1, StreamId: 3, Op: fileStreamOp}
 			// Marshal the header and body
-			r.Marshal(buf, &header)
+			err := r.Marshal(buf, &header)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Unmarshal the header
 			obtainedHeader, err := readHeader(buf.Bytes())

--- a/internal/interbroker/gossip_client_test.go
+++ b/internal/interbroker/gossip_client_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Gossiper", func() {
 })
 
 func newTestTopology(length int, ordinal int) *TopologyInfo {
-	brokers := make([]BrokerInfo, length, length)
+	brokers := make([]BrokerInfo, length)
 	for i := 0; i < length; i++ {
 		brokers[i] = BrokerInfo{
 			IsSelf:   i == ordinal,

--- a/internal/interbroker/replication_test.go
+++ b/internal/interbroker/replication_test.go
@@ -14,6 +14,9 @@ import (
 var _ = Describe("SendToFollowers()", func() {
 	config := new(confMock.Config)
 	config.On("DevMode").Return(false)
+	config.On("ReplicationTimeout").Return(1 * time.Second)
+	config.On("ReplicationWriteTimeout").Return(500 * time.Millisecond)
+	config.On("DevMode").Return(false)
 
 	g := &gossiper{
 		config:      config,

--- a/internal/localdb/queries.go
+++ b/internal/localdb/queries.go
@@ -198,7 +198,9 @@ func (c *client) CommitGeneration(gen1 *Generation, gen2 *Generation) error {
 	}
 
 	// The rollback will be ignored if the tx has been committed
-	defer tx.Rollback()
+	defer func() {
+		_ = tx.Rollback()
+	}()
 
 	insertGenStatement := tx.StmtContext(context.TODO(), c.queries.insertGeneration)
 	insertTxStatement := tx.StmtContext(context.TODO(), c.queries.insertTransaction)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -46,6 +46,11 @@ var (
 		Help: "The total number of re-routed messages received by the broker",
 	})
 
+	InterbrokerDataMissedWrites = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "barco_interbroker_missed_writes_total",
+		Help: "The total number of messages that couldn't be written because the timeout elapsed",
+	})
+
 	SegmentFlushBytes = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "barco_segment_flushed_bytes",
 		Help:    "The amount of bytes flushed to disk",

--- a/internal/ownership/process_local_failover.go
+++ b/internal/ownership/process_local_failover.go
@@ -118,7 +118,7 @@ func (o *generator) processLocalFailover(m *localFailoverGenMessage) creationErr
 		log.Err(err).Msg("Set as committed locally failed (probably local db related)")
 		return newCreationError("Set as committed locally failed")
 	}
-	o.gossiper.SetAsCommitted(peerFollower, gen.Start, nil, gen.Tx)
+	_ = o.gossiper.SetAsCommitted(peerFollower, gen.Start, nil, gen.Tx)
 
 	return nil
 }

--- a/internal/test/conf/mocks/config.go
+++ b/internal/test/conf/mocks/config.go
@@ -465,6 +465,34 @@ func (_m *Config) ReadAheadSize() int {
 	return r0
 }
 
+// ReplicationTimeout provides a mock function with given fields:
+func (_m *Config) ReplicationTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
+// ReplicationWriteTimeout provides a mock function with given fields:
+func (_m *Config) ReplicationWriteTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // SegmentBufferSize provides a mock function with given fields:
 func (_m *Config) SegmentBufferSize() int {
 	ret := _m.Called()


### PR DESCRIPTION
Tries to wait for the replication message to be written on all replicas before returning, that way we make sure data is on all replicas on a healthy cluster.

Additionally, it uses the page cache for the max offset file, which is suitable for this case.

It contains lint fixes for error checks and some test fixes.