### PR TITLE
issues 96

### DIFF
--- a/internal/localdb/client.go
+++ b/internal/localdb/client.go
@@ -2,6 +2,7 @@ package localdb
 
 import (
 	"database/sql"
+	"strings"
 	"sync/atomic"
 
 	"github.com/barcostreams/barco/internal/conf"
@@ -73,7 +74,9 @@ func (c *client) Init() error {
 	c.db = db
 
 	for _, q := range migrationQueries {
-		if _, err := db.Exec(q); err != nil {
+		_, err := db.Exec(q)
+		// When the container restarts, the `ALTER TABLE ...` command generates the error: `duplicate column name: cluster_size`.
+		if err != nil && !strings.Contains(err.Error(), "duplicate column name: cluster_size") {
 			return err
 		}
 	}

--- a/internal/localdb/queries_test.go
+++ b/internal/localdb/queries_test.go
@@ -20,6 +20,17 @@ func TestDbClient(t *testing.T) {
 }
 
 var _ = Describe("Client", func() {
+	Describe("Init()", func() {
+		It("should support running multiple times", func() {
+			client := NewClient(&testConfig{}).(*client)
+			err := client.Init()
+			Expect(client.Init()).NotTo(HaveOccurred())
+
+			// Running a second time
+			err = client.Init()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 	Describe("GetGenerationPerToken()", func() {
 		It("Should retrieve an empty generations when no info is found", func() {
 			client := newTestClient()


### PR DESCRIPTION
When the container restarts, the `ALTER TABLE ...` command generates the error: `duplicate column name: cluster_size`.