### PR TITLE
Change naming convention for consumerId

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,60 +59,15 @@ check out the [Contributing Guide](./CONTRIBUTING.md).
 Producing and consuming messages from Barco is as simple as sending a HTTP request. Use your favorite HTTP client in
 your technology stack to send and retrieve events. Additionally, we also provide a [Go Client Library][go-client].
 
-### Getting Started on Docker
-
-<!-- Start excerpt from docs/getting_started/on_docker/README.md -->
-
-Barco Streams is distributed by default with a minimal size of 3 brokers for production use. You can run a
-single-broker using Docker/Podman with developer mode enabled to get started quickly.
-
-```shell
-docker run --rm --env BARCO_DEV_MODE=true -p 9250-9252:9250-9252 barcostreams/barco:latest
-```
-
-You can start producing messages using a [client library][go-client] or directly invoking the Barco's
-[REST API][rest-api], for example:
-
-```shell
-curl -X POST -i -d '{"hello":"world"}' \
-    -H "Content-Type: application/json" \
-    "http://localhost:9251/v1/topic/my_topic/messages"
-```
-
-Consuming messages is also supported via the REST API or with client libraries. Consuming requires a certain
-request flow to support stateless HTTP clients and still provide ordering and delivery guarantees.
-
-First, register a consumer in the cluster by setting your consumer identifier, the consumer group and
-the topics to subscribed to:
-
-```shell
-curl -X PUT \
-    "http://localhost:9252/v1/consumer/register?consumer_id=1&group=my_app&topic=my_topic"
-```
-
-Note that `consumer_id` and `group` parameter values can be chosen freely by you, you only have to make sure
-those values are uniform across the different instances of your application. In most cases the application name is a
-good choice for consumer `group` name and the application instance id or a random uuid are suited for the `consumer_id`
-value.
-
-After registering, you can start polling from the brokers:
-
-```shell
-curl -i -X POST -H "Accept: application/json" \
-    "http://localhost:9252/v1/consumer/poll?consumer_id=1"
-```
-
-You can continue polling the brokers multiple times to consume data.
-
-<!-- End excerpt -->
-
-Read more about other API endpoints in the [complete getting started guide](./docs/getting_started/on_docker/) or the
-[Barco REST API docs][rest-api]. You can also check out our official
-[Client Library for Go][go-client].
-
-### Getting started on Kubernetes
+### Getting Started on Kubernetes
 
 Get started with Barco on Kubernetes using [this guide](./docs/getting_started/on_kubernetes/).
+
+### Getting Started on Docker
+
+Barco Streams is distributed by default with a minimal size of 3 brokers for production use. You can run a
+single-broker using Docker / Podman with developer mode. Read more about [how to get started with Barco on
+Docker](./docs/getting_started/on_docker/).
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ check out the [Contributing Guide](./CONTRIBUTING.md).
 ## Getting Started
 
 Producing and consuming messages from Barco is as simple as sending a HTTP request. Use your favorite HTTP client in
-your technology stack to send and retrieve events. Additionally, we also provide a [Go Client Library][go-client].
+your technology stack to send and receive events. Additionally, we also provide a [Go Client Library][go-client].
 
 ### Getting Started on Kubernetes
 

--- a/docs/getting_started/on_docker/README.md
+++ b/docs/getting_started/on_docker/README.md
@@ -1,7 +1,5 @@
 # Getting Started with Barco on Docker
 
-<!-- Start Intro -->
-
 Barco Streams is distributed by default with a minimal size of 3 brokers for production use. You can run a
 single-broker using Docker / Podman with developer mode enabled to get started quickly.
 
@@ -15,7 +13,7 @@ You can start producing messages using a [client library][go-client] or directly
 ```shell
 curl -X POST -i -d '{"hello":"world"}' \
     -H "Content-Type: application/json" \
-    "http://localhost:9251/v1/topic/my_topic/messages"
+    "http://localhost:9251/v1/topic/my-topic/messages"
 ```
 
 Consuming messages is also supported via client libraries and using the REST API. Consuming requires a certain
@@ -26,24 +24,22 @@ the topics to subscribed to:
 
 ```shell
 curl -X PUT \
-    "http://localhost:9252/v1/consumer/register?consumer_id=1&group=my_app&topic=my_topic"
+    "http://localhost:9252/v1/consumer/register?consumerId=1&group=my-app&topic=my-topic"
 ```
 
-Note that `consumer_id` and `group` parameter values can be chosen freely by you, you only have to make sure
+Note that `consumerId` and `group` parameter values can be chosen freely by you, you only have to make sure
 those values are uniform across the different instances of your application. In most cases the application name is a
-good choice for consumer `group` name and the application instance id or a random uuid are suited for the `consumer_id`
+good choice for consumer `group` name and the application instance id or a random uuid are suited for the `consumerId`
 value.
 
 After registering, you can start polling from the brokers:
 
 ```shell
 curl -i -X POST -H "Accept: application/json" \
-    "http://localhost:9252/v1/consumer/poll?consumer_id=1"
+    "http://localhost:9252/v1/consumer/poll?consumerId=1"
 ```
 
 You can continue polling the brokers multiple times to consume data.
-
-<!-- End Intro -->
 
 Barco internally tracks the reader position of each consumer group (offset) in relationship to the topic and partition.
 The broker will automatically commit the previously read data when a new poll request is made from the same consumer.
@@ -52,14 +48,14 @@ If at any point in time you want to manually save the reader offset without havi
 can optionally send a commit request:
 
 ```shell
-curl -i -X POST "http://localhost:9252/v1/consumer/commit?consumer_id=1"
+curl -i -X POST "http://localhost:9252/v1/consumer/commit?consumerId=1"
 ```
 
 Once you finished consuming records from a topic, you can optionally send a goodbye request noting that the consumer
 instance will not continue reading. The broker will also attempt to manually commit the offset.
 
 ```shell
-curl -X POST "http://localhost:9252/v1/consumer/goodbye?consumer_id=1"
+curl -X POST "http://localhost:9252/v1/consumer/goodbye?consumerId=1"
 ```
 
 If a consumer does not send requests over a span of 2 minutes to a broker, the brokers will consider the consumer

--- a/docs/getting_started/on_kubernetes/README.md
+++ b/docs/getting_started/on_kubernetes/README.md
@@ -5,7 +5,7 @@ follow [our step by step guide to install on K8s](../../install/kubernetes/).
 
 After deploying Barco on your Kubernetes cluster, you can start producing and consuming messages using a
 [client library][go-client] or directly invoking the Barco's [REST API][rest-api]. The following code snippets
-assume that the `barco` statefulset is deployed in a namespace with the name `streams`.
+assume that the `barco` StatefulSet is deployed in a namespace with the name `streams`.
 
 For the purpose of this guide, let's create a [pod] to produce and consume messages from Barco that will get deleted
 after we exit the shell.
@@ -19,12 +19,12 @@ From the sample pod in your K8s cluster, you can send a POST request to the REST
 ```shell
 curl -X POST -i -d '{"hello":"world"}' \
     -H "Content-Type: application/json" \
-    "http://barco.streams:9251/v1/topic/my_topic/messages"
+    "http://barco.streams:9251/v1/topic/my-topic/messages"
 ```
 
 The Barco service will route to a broker in a round-robin way when no partition key is specified. If you want to
 specify the partition key you can set it in the querystring, for example:
-`http://barco.streams:9251/v1/topic/my_topic/messages?partitionKey=my_key`
+`http://barco.streams:9251/v1/topic/my-topic/messages?partitionKey=my-key`
 
 Consuming messages is also supported via client libraries and using the REST API. Consuming requires a certain
 request flow to support stateless HTTP clients and still provide ordering and delivery guarantees.
@@ -34,19 +34,19 @@ the topics to subscribed to:
 
 ```shell
 curl -X PUT \
-    "http://barco.streams:9252/v1/consumer/register?consumer_id=1&group=my_app&topic=my_topic"
+    "http://barco.streams:9252/v1/consumer/register?consumerId=1&group=my-app&topic=my-topic"
 ```
 
-Note that `consumer_id` and `group` parameter values can be chosen freely by you, you only have to make sure
+Note that `consumerId` and `group` parameter values can be chosen freely by you, you only have to make sure
 those values are uniform across the different instances of your application. In most cases the application name is a
-good choice for consumer `group` name and the application instance id or a random uuid are suited for the `consumer_id`
+good choice for consumer `group` name and the application instance id or a random uuid are suited for the `consumerId`
 value.
 
 After registering, you can start polling from the brokers:
 
 ```shell
 curl -i -X POST -H "Accept: application/json" \
-    "http://barco.streams:9252/v1/consumer/poll?consumer_id=1"
+    "http://barco.streams:9252/v1/consumer/poll?consumerId=1"
 ```
 
 You can continue polling the brokers multiple times to consume data.
@@ -58,14 +58,14 @@ If at any point in time you want to manually save the reader offset without havi
 can optionally send a commit request:
 
 ```shell
-curl -i -X POST "http://barco.streams:9252/v1/consumer/commit?consumer_id=1"
+curl -i -X POST "http://barco.streams:9252/v1/consumer/commit?consumerId=1"
 ```
 
 Once you finished consuming records from a topic, you can optionally send a goodbye request noting that the consumer
 instance will not continue reading. The broker will also attempt to manually commit the offset.
 
 ```shell
-curl -X POST "http://barco.streams:9252/v1/consumer/goodbye?consumer_id=1"
+curl -X POST "http://barco.streams:9252/v1/consumer/goodbye?consumerId=1"
 ```
 
 If a consumer does not send requests over a span of 2 minutes to a broker, the brokers will consider the consumer

--- a/docs/rest_api/README.md
+++ b/docs/rest_api/README.md
@@ -85,12 +85,12 @@ Responds HTTP status `200 OK` when the data has been stored and replicated.
 
 #### Examples:
 
-Sending an event.
+Sending an event with the partition key set.
 
 ```shell
-$ curl -X POST -i -d '{"product_id": 123, "units": -5}' \
+$ curl -X POST -i -d '{"productId": 123, "units": -5}' \
     -H "Content-Type: application/json" \
-    "http://barco.streams:9251/v1/topic/product_stock/messages?partitionKey=123"
+    "http://barco.streams:9251/v1/topic/product-stock/messages?partitionKey=123"
 ```
 
 ### `GET /status`
@@ -114,18 +114,18 @@ Registers a consumer in all the brokers, it's the first step in the read flow an
 
 | Key | Type | Description |
 | --- | ---- | ----------- |
-| `consumer_id` | `string` | A text value chosen by you to identify the consumer in the read flow. In general The application instance id or a random uuid are suited for the `consumer_id` value, as long as you reuse the id across the following requests of the read flow. |
+| `consumerId` | `string` | A text value chosen by you to identify the consumer in the read flow. In general The application instance id or a random uuid are suited for the `consumerId` value, as long as you reuse the id across the following requests of the read flow. |
 | `group` | `string` (optional)| The name of the consumer group, In most cases the application name is a good choice for consumer `group` name. Defaults to `"default"`. |
 | `topic` | `string[]` | The topics to subscribe to. In case it is more than one, you can send repeating the parameter key and value, for example: `?topic=a&topic=b`. |
 | `onNewGroup` | `string` | Determines the start offset when there's no information for a given consumer group. Possible values are `startFromLatest` (default) and `startFromEarliest`.|
 
 #### Example
 
-Register a consumer in the cluster subscribing to the topic `"product_stock"`.
+Register a consumer in the cluster subscribing to the topic `"product-stock"`.
 
 ```shell
 $ curl -X PUT \
-    "http://barco.streams:9252/v1/consumer/register?consumer_id=1&group=product_stock_updater&topic=product_stock"
+    "http://barco.streams:9252/v1/consumer/register?consumerId=1&group=product-stock-updater&topic=product-stock"
 ```
 
 #### Response
@@ -138,7 +138,7 @@ Responds HTTP status `200 OK` when the consumer is registered on all brokers.
 
 | Key | Type | Description |
 | --- | ---- | ----------- |
-| `consumer_id` | `string` (required) | The consumer identifier used to register the consumer. |
+| `consumerId` | `string` (required) | The consumer identifier used to register the consumer. |
 
 #### Response
 
@@ -163,11 +163,11 @@ Register endpoint from above and retry.
 
 ```
 $ curl -i -X POST -H "Accept: application/json"\
-    "http://barco.streams:9252/v1/consumer/poll?consumer_id=1"
+    "http://barco.streams:9252/v1/consumer/poll?consumerId=1"
 HTTP/1.1 200 OK
 Content-Type: application/json
 
-[{"topic":"product_stock","token":"-9223372036854775808","rangeIndex":0,"version":1,"startOffset":"6","values":[{"product_id": 123, "units": -1}, {"product_id": 123, "units": 20}]}]
+[{"topic":"product-stock","token":"-9223372036854775808","rangeIndex":0,"version":1,"startOffset":"6","values":[{"productId": 123, "units": -1}, {"productId": 123, "units": 20}]}]
 ```
 
 ### `POST /v1/consumer/commit`
@@ -180,7 +180,7 @@ the position of the reader.
 
 | Key | Type | Description |
 | --- | ---- | ----------- |
-| `consumer_id` | `string` | The consumer identifier used to register the consumer. |
+| `consumerId` | `string` | The consumer identifier used to register the consumer. |
 
 #### Response
 
@@ -193,7 +193,7 @@ Responds HTTP status `409 Conflict` when the consumer is not considered to be re
 Manually commit the position of the reader.
 
 ```shell
-$ curl -i -X POST "http://barco.streams:9252/v1/consumer/commit?consumer_id=1"
+$ curl -i -X POST "http://barco.streams:9252/v1/consumer/commit?consumerId=1"
 ```
 
 ### `POST /v1/consumer/goodbye`
@@ -205,7 +205,7 @@ loop.
 
 | Key | Type | Description |
 | --- | ---- | ----------- |
-| `consumer_id` | `string` | The consumer identifier used to register the consumer. |
+| `consumerId` | `string` | The consumer identifier used to register the consumer. |
 
 #### Response
 

--- a/internal/test/integration/roundtrip_test.go
+++ b/internal/test/integration/roundtrip_test.go
@@ -402,6 +402,7 @@ var _ = Describe("A 3 node cluster", func() {
 			registerStatelessConsumer(client, "c1", group, topic, StartFromEarliest)
 
 			// Try register on the second one: it should be a noop
+			// Use legacy "consumer_id" querystring parameter
 			const registerUrl = "http://127.0.0.1:9252/v1/consumer/register?consumer_id=%s&group=%s&topic=%s&onNewGroup=%s"
 			req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf(registerUrl, "c1", group, topic, StartFromEarliest), nil)
 			resp, err := client.Do(req)
@@ -418,7 +419,7 @@ var _ = Describe("A 3 node cluster", func() {
 			}
 
 			for i := 0; i < 2; i++ {
-				req, _ := http.NewRequest(http.MethodPost, "http://127.0.0.1:9252/v1/consumer/goodbye?consumer_id=c1", nil)
+				req, _ := http.NewRequest(http.MethodPost, "http://127.0.0.1:9252/v1/consumer/goodbye?consumerId=c1", nil)
 				resp, err := client.Do(req)
 				Expect(err).NotTo(HaveOccurred())
 				if i == 0 {
@@ -545,7 +546,7 @@ func pollTimes(client *http.Client, consumerId string, times int) []map[string]a
 	messages := []map[string]any{}
 	for i := 0; i < times; i++ {
 		for brokerIp := 1; brokerIp <= 3; brokerIp++ {
-			pollUrl := fmt.Sprintf("http://127.0.0.%d:9252/v1/consumer/poll?consumer_id=%s", brokerIp, consumerId)
+			pollUrl := fmt.Sprintf("http://127.0.0.%d:9252/v1/consumer/poll?consumerId=%s", brokerIp, consumerId)
 			req, _ := http.NewRequest(http.MethodPost, pollUrl, nil)
 			req.Header.Add("Accept", "application/json")
 			resp, err := client.Do(req)
@@ -594,7 +595,7 @@ func produceOrderedJson(client *TestClient, topic string, startIndex int, totalM
 }
 
 func registerStatelessConsumer(client *http.Client, consumerId, group, topic string, onNewGroup OffsetResetPolicy) {
-	const registerUrl = "http://127.0.0.1:9252/v1/consumer/register?consumer_id=%s&group=%s&topic=%s&onNewGroup=%s"
+	const registerUrl = "http://127.0.0.1:9252/v1/consumer/register?consumerId=%s&group=%s&topic=%s&onNewGroup=%s"
 	req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf(registerUrl, consumerId, group, topic, onNewGroup), nil)
 	resp, err := client.Do(req)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Use `consumerId` and deprecate `consumer_id`.

Resolves #95.